### PR TITLE
avoid mixed content warnings when editing template.

### DIFF
--- a/templates/versafix-1/template-versafix-1.html
+++ b/templates/versafix-1/template-versafix-1.html
@@ -494,7 +494,7 @@
                       -ko-font-family: @externalTextStyle.face; -ko-color: @externalTextStyle.color"><img
                        data-ko-editable="image.src" width="258" data-ko-placeholder-height="150" 
                         style="-ko-attr-alt: @image.alt; width: 100%; max-width: 258px; -ko-attr-width: @imageWidth; -ko-max-width: @[imageWidth]px;"
-                        src="http://mosaico.io/srv/f-default/img?method=placeholder&amp;params=258%2C150" vspace="0" hspace="0" border="0" alt="" /></a>
+                        src="https://mosaico.io/srv/f-default/img?method=placeholder&amp;params=258%2C150" vspace="0" hspace="0" border="0" alt="" /></a>
 </div>
 <!--[if (gte mso 9)|(lte ie 8)]></td></tr></table><![endif]-->
 
@@ -534,7 +534,7 @@
                           <a data-ko-link="image.url" href="">
                             <img data-ko-editable="image.src" border="0" hspace="0" vspace="0" width="166"
                               data-ko-placeholder-height="130" class="mobile-full" alt=""
-                              src="http://mosaico.io/srv/f-default/img?method=placeholder&amp;params=166%2C130" 
+                              src="https://mosaico.io/srv/f-default/img?method=placeholder&amp;params=166%2C130" 
                               style="vertical-align: top; width: 100%; height: auto; -ko-attr-width: @imageWidth; max-width: 166px; -ko-max-width: @[imageWidth]px; -ko-attr-alt: @image.alt" />
                           </a>
                         </td>
@@ -590,7 +590,7 @@
                         <td width="100%" valign="top" align="left" class="links-color">
                           <a data-ko-link="image.url" href="">
                             <img data-ko-editable="image.src" border="0" hspace="0" vspace="0" width="166" data-ko-placeholder-height="130" class="mobile-full"
-                              src="http://mosaico.io/srv/f-default/img?method=placeholder&amp;params=166%2C130" class="mobile-full" 
+                              src="https://mosaico.io/srv/f-default/img?method=placeholder&amp;params=166%2C130" class="mobile-full" 
                               alt="" style="vertical-align:top; width: 100%; height: auto; -ko-attr-width: @imageWidth; max-width: 166px; -ko-max-width: @[imageWidth]px; -ko-attr-alt: @image.alt" />
                           </a>
                         </td>
@@ -627,7 +627,7 @@
             <td width="100%" valign="top" align="left" class="links-color">
               <a data-ko-link="image.url" href="">
                 <img data-ko-editable="image.src" border="0" hspace="0" vspace="0" width="534" data-ko-placeholder-height="200"
-                  src="http://mosaico.io/srv/f-default/img?method=placeholder&amp;params=534%2C200" class="mobile-full" 
+                  src="https://mosaico.io/srv/f-default/img?method=placeholder&amp;params=534%2C200" class="mobile-full" 
                   alt="" style="vertical-align:top; max-width:534px; width: 100%; height: auto;
                   -ko-attr-alt: @image.alt" />
               </a>
@@ -758,7 +758,7 @@
                         <td width="100%" valign="top" align="left" class="links-color" style="padding-bottom: 9px">
                           <a data-ko-link="leftImage.url" href="">
                             <img data-ko-editable="leftImage.src" border="0" hspace="0" vspace="0" width="166" height="90"
-                              src="http://mosaico.io/srv/f-default/img?method=placeholder&amp;params=166%2C90" class="mobile-full" 
+                              src="https://mosaico.io/srv/f-default/img?method=placeholder&amp;params=166%2C90" class="mobile-full" 
                              alt="" style="vertical-align:top; width: 100%; height: auto; -ko-attr-height: @imageHeight; 
                                -ko-attr-alt: @leftImage.alt" />
                           </a>
@@ -806,7 +806,7 @@
                         <td width="100%" valign="top" align="left" class="links-color" style="padding-bottom: 9px">
                           <a data-ko-link="middleImage.url">
                             <img data-ko-editable="middleImage.src" border="0" hspace="0" vspace="0" width="166" height="90"
-                              src="http://mosaico.io/srv/f-default/img?method=placeholder&amp;params=166%2C90" class="mobile-full" 
+                              src="https://mosaico.io/srv/f-default/img?method=placeholder&amp;params=166%2C90" class="mobile-full" 
                               alt="" style="vertical-align:top; width: 100%; height: auto; -ko-attr-height: @imageHeight; 
                               -ko-attr-alt: @middleImage.alt" />
                           </a>
@@ -855,7 +855,7 @@
                         <td width="100%" valign="top" align="left" class="links-color" style="padding-bottom: 9px">
                           <a data-ko-link="rightImage.url">
                             <img data-ko-editable="rightImage.src" border="0" hspace="0" vspace="0" width="166" height="90"
-                              src="http://mosaico.io/srv/f-default/img?method=placeholder&amp;params=166%2C90" class="mobile-full" 
+                              src="https://mosaico.io/srv/f-default/img?method=placeholder&amp;params=166%2C90" class="mobile-full" 
                               alt="" style="vertical-align:top; width: 100%; height: auto; -ko-attr-height: @imageHeight; 
                               -ko-attr-alt: @rightImage.alt" />
                           </a>
@@ -932,7 +932,7 @@
                         <td width="100%" align="left" class="links-color" style="padding-bottom: 9px">
                           <a data-ko-link="leftImage.url">
                             <img data-ko-editable="leftImage.src" border="0" hspace="0" vspace="0" width="258" height="100"
-                              src="http://mosaico.io/srv/f-default/img?method=placeholder&amp;params=258%2C100" class="mobile-full" 
+                              src="https://mosaico.io/srv/f-default/img?method=placeholder&amp;params=258%2C100" class="mobile-full" 
                               alt="" style="vertical-align:top; width: 100%; height: auto; -ko-attr-height: @imageHeight; 
                               -ko-attr-alt: @leftImage.alt" />
                           </a>
@@ -981,7 +981,7 @@
                         <td width="100%" valign="top" align="left" class="links-color" style="padding-bottom: 9px">
                           <a data-ko-link="rightImage.url">
                             <img data-ko-editable="rightImage.src" border="0" hspace="0" vspace="0" width="258" height="100"
-                              src="http://mosaico.io/srv/f-default/img?method=placeholder&amp;params=258%2C100" class="mobile-full" 
+                              src="https://mosaico.io/srv/f-default/img?method=placeholder&amp;params=258%2C100" class="mobile-full" 
                               alt="" style="vertical-align:top; width: 100%; height: auto; -ko-attr-height: @imageHeight; 
                               -ko-attr-alt: @rightImage.alt" />
                           </a>
@@ -1119,7 +1119,7 @@
             <td valign="top" align="center">
               <a data-ko-link="image.url" href="" style="text-decoration: none;"><img data-ko-editable="image.src"
                   hspace="0" border="0" vspace="0" width="570" data-ko-placeholder-height="200"
-                  src="http://mosaico.io/srv/f-default/img?method=placeholder&amp;params=570%2C200" class="mobile-full"
+                  src="https://mosaico.io/srv/f-default/img?method=placeholder&amp;params=570%2C200" class="mobile-full"
                   alt="" style="max-width: 570px; display: block; border-radius: 0px; width: 100%; height: auto; font-size: 13px;
                   font-family: Arial, Helvetica, sans-serif; color: #3f3f3f; -ko-font-size: @[longTextStyle.size]px;
                   -ko-font-family: @longTextStyle.face; -ko-color: @longTextStyle.color; -ko-attr-alt: @image.alt;" /></a>
@@ -1132,7 +1132,7 @@
             <td valign="top" align="center">
               <a data-ko-link="image.url" href="" style="text-decoration: none;"><img data-ko-editable="image.src"
                   hspace="0" border="0" vspace="0" width="534" data-ko-placeholder-height="280"
-                  src="http://mosaico.io/srv/f-default/img?method=placeholder&amp;params=534%2C280" class="mobile-full"
+                  src="https://mosaico.io/srv/f-default/img?method=placeholder&amp;params=534%2C280" class="mobile-full"
                   alt="" style="max-width: 534px; display: block; border-radius: 0px; width: 100%; height: auto; font-size: 13px;
                   font-family: Arial, Helvetica, sans-serif; color: #3f3f3f; -ko-font-size: @[longTextStyle.size]px;
                   -ko-font-family: @longTextStyle.face; -ko-color: @longTextStyle.color; -ko-attr-alt: @image.alt;" /></a>
@@ -1164,7 +1164,7 @@
 <div style="display:inline-block; max-width:285px; vertical-align:top; width:100%; width:100%; " class="mobile-full"> 
               <a data-ko-link="leftImage.url" href="" style="text-decoration: none;"><img data-ko-editable="leftImage.src"
                   hspace="0" align="left" border="0" vspace="0" width="285" height="180" class="mobile-full"
-                  src="http://mosaico.io/srv/f-default/img?method=placeholder&amp;params=285%2C180"
+                  src="https://mosaico.io/srv/f-default/img?method=placeholder&amp;params=285%2C180"
                   alt="" style="display: block; border-radius: 0px; width: 100%; height: auto;font-size: 13px;
                   font-family: Arial, Helvetica, sans-serif; color: #3f3f3f; -ko-font-size: @[longTextStyle.size]px; -ko-font-family: @longTextStyle.face;
                   -ko-color: @longTextStyle.color; -ko-attr-height: @imageHeight; -ko-attr-alt: @leftImage.alt;" /></a>
@@ -1173,7 +1173,7 @@
 <![endif]--><div style="display:inline-block; max-width:285px; vertical-align:top; width:100%; width:100%; " class="mobile-full"> 
               <a data-ko-link="rightImage.url" href="" style="text-decoration: none;"><img data-ko-editable="rightImage.src"
                   hspace="0" align="right" border="0" vspace="0" width="285" height="180" class="mobile-full"
-                  src="http://mosaico.io/srv/f-default/img?method=placeholder&amp;params=285%2C180"
+                  src="https://mosaico.io/srv/f-default/img?method=placeholder&amp;params=285%2C180"
                   alt="" style="display: block; border-radius: 0px; width: 100%; height: auto;font-size: 13px;
                   font-family: Arial, Helvetica, sans-serif; color: #3f3f3f; -ko-font-size: @[longTextStyle.size]px; -ko-font-family: @longTextStyle.face;
                   -ko-color: @longTextStyle.color; -ko-attr-height: @imageHeight; -ko-attr-alt: @rightImage.alt;" /></a>
@@ -1198,7 +1198,7 @@
                     <a data-ko-link="leftImage.url" href="" style="text-decoration: none;">
                       <img data-ko-editable="leftImage.src"
                         hspace="0" align="left" border="0" vspace="0" width="258" height="180"
-                        src="http://mosaico.io/srv/f-default/img?method=placeholder&amp;params=258%2C180" class="mobile-full"
+                        src="https://mosaico.io/srv/f-default/img?method=placeholder&amp;params=258%2C180" class="mobile-full"
                         alt="" style="display: block; border-radius: 0px; width: 100%; height: auto;font-size: 13px;
                         font-family: Arial, Helvetica, sans-serif; color: #3f3f3f; -ko-font-size: @[longTextStyle.size]px; -ko-font-family: @longTextStyle.face;
                         -ko-color: @longTextStyle.color; -ko-attr-height: @imageHeight; -ko-attr-alt: @leftImage.alt;" /></a>
@@ -1215,7 +1215,7 @@
                   <td valign="top">
                     <a data-ko-link="rightImage.url" href="" style="text-decoration: none;"><img data-ko-editable="rightImage.src"
                         hspace="0" align="right" border="0" vspace="0" width="258" height="180"
-                        src="http://mosaico.io/srv/f-default/img?method=placeholder&amp;params=258%2C180" class="mobile-full"
+                        src="https://mosaico.io/srv/f-default/img?method=placeholder&amp;params=258%2C180" class="mobile-full"
                         alt="" style="display: block; border-radius: 0px; width: 100%; height: auto;font-size: 13px;
                         font-family: Arial, Helvetica, sans-serif; color: #3f3f3f; -ko-font-size: @[longTextStyle.size]px; -ko-font-family: @longTextStyle.face;
                         -ko-color: @longTextStyle.color; -ko-attr-height: @imageHeight; -ko-attr-alt: @rightImage.alt;" /></a>
@@ -1254,7 +1254,7 @@
 <div style="display:inline-block; max-width:190px; vertical-align:top; width:100%; " class="mobile-full"> 
               <a data-ko-link="leftImage.url" href="" style="text-decoration: none;"><img data-ko-editable="leftImage.src"
                   hspace="0" align="left" border="0" vspace="0" width="190" height="160" class="mobile-full"
-                  src="http://mosaico.io/srv/f-default/img?method=placeholder&amp;params=190%2C160"
+                  src="https://mosaico.io/srv/f-default/img?method=placeholder&amp;params=190%2C160"
                   alt="" style="display: block; border-radius: 0px; width: 100%; height: auto;font-size: 13px;
                   font-family: Arial, Helvetica, sans-serif; color: #3f3f3f; -ko-font-size: @[longTextStyle.size]px; -ko-font-family: @longTextStyle.face;
                   -ko-color: @longTextStyle.color; -ko-attr-height: @imageHeight; -ko-attr-alt: @leftImage.alt;" /></a>
@@ -1263,7 +1263,7 @@
 <![endif]--><div style="display:inline-block; max-width:190px; vertical-align:top; width:100%; " class="mobile-full"> 
               <a data-ko-link="middleImage.url" href="" style="text-decoration: none;"><img data-ko-editable="middleImage.src"
                   hspace="0" align="left" border="0" vspace="0" width="190" height="160" class="mobile-full"
-                  src="http://mosaico.io/srv/f-default/img?method=placeholder&amp;params=190%2C160"
+                  src="https://mosaico.io/srv/f-default/img?method=placeholder&amp;params=190%2C160"
                   alt="" style="display: block; border-radius: 0px; width: 100%; height: auto;font-size: 13px;
                   font-family: Arial, Helvetica, sans-serif; color: #3f3f3f; -ko-font-size: @[longTextStyle.size]px; -ko-font-family: @longTextStyle.face;
                   -ko-color: @longTextStyle.color; -ko-attr-height: @imageHeight; -ko-attr-alt: @middleImage.alt;" /></a>
@@ -1272,7 +1272,7 @@
 <![endif]--><div style="display:inline-block; max-width:190px; vertical-align:top; width:100%; " class="mobile-full"> 
               <a data-ko-link="rightImage.url" href="" style="text-decoration: none;"><img data-ko-editable="rightImage.src"
                   hspace="0" align="right" border="0" vspace="0" width="190" height="160" class="mobile-full"
-                  src="http://mosaico.io/srv/f-default/img?method=placeholder&amp;params=190%2C160"
+                  src="https://mosaico.io/srv/f-default/img?method=placeholder&amp;params=190%2C160"
                   alt="" style="display: block; border-radius: 0px; width: 100%; height: auto;font-size: 13px;
                   font-family: Arial, Helvetica, sans-serif; color: #3f3f3f; -ko-font-size: @[longTextStyle.size]px; -ko-font-family: @longTextStyle.face;
                   -ko-color: @longTextStyle.color; -ko-attr-height: @imageHeight; -ko-attr-alt: @rightImage.alt;" /></a>
@@ -1296,7 +1296,7 @@
                   <td valign="top">
                     <a data-ko-link="leftImage.url" href="" style="text-decoration: none;"><img data-ko-editable="leftImage.src"
                       hspace="0" align="left" border="0" vspace="0" width="166" height="160"
-                      src="http://mosaico.io/srv/f-default/img?method=placeholder&amp;params=166%2C160" class="mobile-full"
+                      src="https://mosaico.io/srv/f-default/img?method=placeholder&amp;params=166%2C160" class="mobile-full"
                       alt="" style="display: block; border-radius: 0px; width: 100%; height: auto;font-size: 13px;
                       font-family: Arial, Helvetica, sans-serif; color: #3f3f3f; -ko-font-size: @[longTextStyle.size]px; -ko-font-family: @longTextStyle.face;
                       -ko-color: @longTextStyle.color; -ko-attr-height: @imageHeight; -ko-attr-alt: @leftImage.alt;" /></a>
@@ -1313,7 +1313,7 @@
                   <td valign="top">
                     <a data-ko-link="middleImage.url" href="" style="text-decoration: none"><img data-ko-editable="middleImage.src"
                       hspace="0" align="left" border="0" vspace="0" width="166" height="160"
-                      src="http://mosaico.io/srv/f-default/img?method=placeholder&amp;params=166%2C160" class="mobile-full"
+                      src="https://mosaico.io/srv/f-default/img?method=placeholder&amp;params=166%2C160" class="mobile-full"
                       alt="" style="display: block; border-radius: 0px; width: 100%; height: auto;font-size: 13px;
                       font-family: Arial, Helvetica, sans-serif; color: #3f3f3f; -ko-font-size: @[longTextStyle.size]px; -ko-font-family: @longTextStyle.face;
                       -ko-color: @longTextStyle.color; -ko-attr-height: @imageHeight; -ko-attr-alt: @middleImage.alt;" /></a>
@@ -1330,7 +1330,7 @@
                   <td valign="top">
                     <a data-ko-link="rightImage.url" href="" style="text-decoration: none"><img data-ko-editable="rightImage.src"
                       hspace="0" align="right" border="0" vspace="0" width="166" height="160"
-                      src="http://mosaico.io/srv/f-default/img?method=placeholder&amp;params=166%2C160" class="mobile-full"
+                      src="https://mosaico.io/srv/f-default/img?method=placeholder&amp;params=166%2C160" class="mobile-full"
                       alt="" style="display: block; border-radius: 0px; width: 100%; height: auto;font-size: 13px;
                       font-family: Arial, Helvetica, sans-serif; color: #3f3f3f; -ko-font-size: @[longTextStyle.size]px; -ko-font-family: @longTextStyle.face;
                       -ko-color: @longTextStyle.color; -ko-attr-height: @imageHeight; -ko-attr-alt: @rightImage.alt;" /></a>


### PR DESCRIPTION
None of these image references should ultimately be sent out.

Yet, when editing a message via the browser using an https connection,
the user gets a mixed content warning because the https page is
displaying images over http. The mosaico.io site fully supports https
so there seems to be no good reason to pull them in via http.

See veda-consulting/uk.co.vedaconsulting.mosaico#288