### PR TITLE
Replacing 'TITLE' by mail subject in template HTML

### DIFF
--- a/templates/versafix-1/template-versafix-1.html
+++ b/templates/versafix-1/template-versafix-1.html
@@ -4,7 +4,7 @@
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
   <meta name="viewport" content="initial-scale=1.0" />
   <meta name="format-detection" content="telephone=no" />
-  <title style="-ko-bind-text: @titleText">TITLE</title>
+  <title style="-ko-bind-text: @titleText">[subject]</title>
   <style type="text/css">
     @supports -ko-blockdefs {
       id { widget: id }


### PR DESCRIPTION
In the mailings sent from CiviCRM, there's usually a "Public view" link. When you visit that page, the page title is simple "TITLE".

This fix is replacing 'TITLE' by e-mail subject in generated HTML

Sequel of:
[uk.co.vedaconsulting.mosaico - 280](https://github.com/veda-consulting/uk.co.vedaconsulting.mosaico/pull/280)