### PR TITLE
separate url for placeholder images with it's own permissions

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -43,7 +43,7 @@ var applyBindingOptions = function(options, ko) {
 
   ko.bindingHandlers.wysiwygSrc.placeholderUrl = function(width, height, text) {
     // DS: determine if to use ? or &. ? alone is certainly not going to work for wordpress
-    return options.imgProcessorBackend + ((options.imgProcessorBackend.indexOf('?') == -1) ? '?' : '&') + "method=" + 'placeholder' + "&params=" + width + encodeURIComponent(",") + height;
+    return options.imgPlaceholderUrl + ((options.imgPlaceholderUrl.indexOf('?') == -1) ? '?' : '&') + "method=" + 'placeholder' + "&params=" + width + encodeURIComponent(",") + height;
   };
 
   // pushes custom tinymce configurations from options to the binding


### PR DESCRIPTION
Placeholder images don't work for Joomla installs as they are permissioned and route via frontend url in Joomla.

See https://github.com/veda-consulting-company/uk.co.vedaconsulting.mosaico/pull/406.

The intention is to create a new url for placeholder images with it's own permissions, and could be exposed as backend url than frontend.