### PR TITLE
disable paste-as-text option

### DIFF
--- a/src/js/bindings/wysiwygs.js
+++ b/src/js/bindings/wysiwygs.js
@@ -344,7 +344,7 @@ ko.bindingHandlers.wysiwyg = {
       // we have to disable preview_styles otherwise tinymce push inline every style he thinks will be applied and
       // this makes the style menu to inherit color/font-family and more.
       preview_styles: false,
-      paste_as_text: true,
+      paste_as_text: false,
       language: 'en',
       schema: "html5",
 


### PR DESCRIPTION
We have a small issue that is annoying for our users: When pasting text in a Mosaico template block, it is by default pasting as text and removes links and formatting. 
For the moment the behaviour of that button is really strange as when you click on it once it doesn’t do anything (or toggle from paste as text to paste as text :-)) and you have to click it two or three time for it to actually toggle to normal paste.

This patch disables the paste-as-text option. 